### PR TITLE
Use numify instead of stringify

### DIFF
--- a/lib/Dist/Zilla/Plugin/MinimumPerlFast.pm
+++ b/lib/Dist/Zilla/Plugin/MinimumPerlFast.pm
@@ -39,7 +39,7 @@ has max => (
 
 sub _build_version {
 	my $self = shift;
-	return List::Util::max($self->min, map { Perl::MinimumVersion::Fast->new(\$_->content)->minimum_version->stringify } @{ $self->found_files });
+	return List::Util::max($self->min, map { Perl::MinimumVersion::Fast->new(\$_->content)->minimum_version->numify } @{ $self->found_files });
 }
 
 sub register_prereqs {


### PR DESCRIPTION
If a perl file uses "use v5.10", stringify returns "v5.10". This is not a number that can be used in List::Util::max. Therefor numify should be used. That method returns "5.010".